### PR TITLE
Add explanation section

### DIFF
--- a/plugins/yivi-client/state-client.js
+++ b/plugins/yivi-client/state-client.js
@@ -217,6 +217,7 @@ module.exports = class YiviStateClient {
                   payload: {
                     qr: JSON.stringify(this._mappings.sessionPtr),
                     showBackButton: prevTransition === 'chooseQR',
+                    type: this._mappings.sessionPtr.irmaqr,
                   },
                 }
               : false;
@@ -226,6 +227,7 @@ module.exports = class YiviStateClient {
                   transition: 'showYiviButton',
                   payload: {
                     mobile: this._getMobileUrl(this._mappings.sessionPtr),
+                    type: this._mappings.sessionPtr.irmaqr,
                   },
                 }
               : false;

--- a/plugins/yivi-web/README.md
+++ b/plugins/yivi-web/README.md
@@ -79,3 +79,10 @@ becomes visible when the user presses the button to open the Yivi app, and the a
 So, when `showHelper` is set to false, the helper is only visible as fallback and disappears
 again as soon as the happy flow continues. When `showHelper` is set to true, the helper will
 be visible unconditionally._
+
+### showExplanation
+
+The option `showExplanation` is a boolean that determines if the explanation text
+should be shown. Default is false.
+
+_Note: the explanation text can be updated using the `translations` option.

--- a/plugins/yivi-web/dom-manipulations.js
+++ b/plugins/yivi-web/dom-manipulations.js
@@ -6,8 +6,10 @@ module.exports = class DOMManipulations {
     this._translations = options.translations;
     this._showHelper = options.showHelper;
     this._showCloseButton = options.showCloseButton;
+    this._showExplanation = options.showExplanation;
     this._fallbackDelay = options.fallbackDelay;
     this._eventHandlers = {};
+    this._applicationName = options.applicationName;
 
     this._clickCallback = clickCallback;
     this._pairingCodeCallback = pairingCodeCallback;
@@ -20,6 +22,7 @@ module.exports = class DOMManipulations {
     const newPartial = this._stateToPartialMapping()[state.newState];
     if (!newPartial) throw new Error(`I don't know how to render '${state.newState}'`);
     this._renderPartial(newPartial, state);
+    this._renderExplanation(state);
 
     if (state.oldState === 'ShowingYiviButton' && !this._showHelper) {
       this._element.querySelector('.yivi-web-header').classList.remove('yivi-web-show-helper');
@@ -184,12 +187,34 @@ module.exports = class DOMManipulations {
             : ''
         }
       </div>
+      ${
+        this._showExplanation
+          ? `
+        <div class="yivi-web-explanation" style="display: none;"></div>
+      `
+          : ''
+      }
       <div class="yivi-web-content">
         <div class="yivi-web-centered">
           ${content}
         </div>
       </div>
     `;
+  }
+
+  _renderExplanation({ newState, payload }) {
+    if (newState === undefined) {
+      return;
+    }
+
+    const content = this._translations.explanation(this._applicationName, payload?.type)[newState];
+    if (!content) {
+      this._element.querySelector('.yivi-web-explanation').style.display = 'none';
+      return;
+    }
+
+    this._element.querySelector('.yivi-web-explanation').style.display = null;
+    this._element.querySelector('.yivi-web-explanation').innerHTML = content;
   }
 
   /** States markup **/

--- a/plugins/yivi-web/translations/en.js
+++ b/plugins/yivi-web/translations/en.js
@@ -15,5 +15,20 @@ module.exports = {
   success: 'Success!',
   cancel: 'Cancel',
   pairing: 'Enter the pairing code that your Yivi app currently shows.',
-  pairingFailed: (code) => `The pairing code ${code} does not match the code in your Yivi app. Please try again.`
+  pairingFailed: (code) => `The pairing code ${code} does not match the code in your Yivi app. Please try again.`,
+  explanation: function (applicationName, type) {
+    const explanations = {};
+
+    // Type can be 'disclosing', 'issuing' or 'signing'
+    // Only available for ShowingQRCode and ShowingYiviButton states
+    if (type === 'disclosing') {
+      explanations.ShowingQRCode = `<p>Follow the following steps:</p><ol><li>Scan the QR-code with your Yivi-app.</li><li>Choose in the Yivi-app if you want share the requested data with ${applicationName}.</li></ol>`;
+    }
+
+    if (type === 'issuing') {
+      explanations.ShowingQRCode = `<p>Follow the following steps:</p><ol><li>Scan the QR-code with your Yivi-app.</li><li>Choose in the Yivi-app if you want to add the data.</li></ol>`;
+    }
+
+    return explanations;
+  }
 };

--- a/plugins/yivi-web/translations/nl.js
+++ b/plugins/yivi-web/translations/nl.js
@@ -15,5 +15,20 @@ module.exports = {
   success: 'Gelukt!',
   cancel: 'Annuleer',
   pairing: 'Vul de koppelcode in die in jouw Yivi-app verschijnt.',
-  pairingFailed: (code) => `De koppelcode ${code} komt niet overeen met de code in je Yivi-app. Probeer het opnieuw.`
+  pairingFailed: (code) => `De koppelcode ${code} komt niet overeen met de code in je Yivi-app. Probeer het opnieuw.`,
+  explanation: function (applicationName, type) {
+    const explanations = {};
+
+    // Type can be 'disclosing', 'issuing' or 'signing'
+    // Only available for ShowingQRCode and ShowingYiviButton states
+    if (type === 'disclosing') {
+      explanations.ShowingQRCode = `<p>Doorloop de volgende stappen:</p><ol><li>Scan deze QR-code met uw Yivi-app.</li><li>Kies in uw Yivi-app of u de gevraagde gegevens wilt delen met ${applicationName}.</li></ol>`;
+    }
+
+    if (type === 'issuing') {
+      explanations.ShowingQRCode = `<p>Doorloop de volgende stappen:</p><ol><li>Scan deze QR-code met uw Yivi-app.</li><li>Kies in uw Yivi-app of u de gegevens wilt toevoegen.</li></ol>`;
+    }
+
+    return explanations;
+  }
 };

--- a/yivi-css/src/components/yivi-form.scss
+++ b/yivi-css/src/components/yivi-form.scss
@@ -96,6 +96,25 @@ Styleguide Components.Yivi login
 
   box-shadow: 0px 5px 16px rgba(0, 0, 0, 0.15);
 
+  .yivi-web-explanation {
+    @include reset;
+    flex: 1 1 auto;
+    margin: 0 1rem 1rem 1rem;
+    padding: 1rem;
+
+    background-color: $content-bg-color;
+    border-radius: $border-radius;
+
+    @include font($size: 16px, $weight: 18px);
+    color: $yivi-anthracite;
+
+    p {
+      @include reset;
+      @include font($size: 16px, $weight: 18px);
+      color: $yivi-anthracite;
+    }
+  }
+
   .yivi-web-content {
     @include reset;
     @include center;


### PR DESCRIPTION
Basic working implementation of how we could implement an explanation section for a specific state.

Would like to receive feedback!

Yivi popup issuing flow in dutch with the changes in our application.
![image](https://github.com/privacybydesign/yivi-frontend-packages/assets/1367665/c1d8e62a-6d56-45d6-b5d2-11dd3d8ee1a2)

After scanning the QR code with the Yivi app, the explanation is gone. I think the explanation is also not needed because of the message that is visible. But it is possible to add another explanation based on the state in the language files.
![image](https://github.com/privacybydesign/yivi-frontend-packages/assets/1367665/60aab85c-88ab-4e66-bfa1-3dda69465616)

Currently the height is fixed. We need to update that to support this additional section.
https://github.com/privacybydesign/yivi-frontend-packages/blob/da76c44b0698563bc95c66c3552c2cb914747ec0/yivi-css/src/components/yivi-form.scss#L86-L88