### PR TITLE
Use link instead of json for QR

### DIFF
--- a/plugins/yivi-client/state-client.js
+++ b/plugins/yivi-client/state-client.js
@@ -215,7 +215,7 @@ module.exports = class YiviStateClient {
               ? {
                   transition: 'showQRCode',
                   payload: {
-                    qr: JSON.stringify(this._mappings.sessionPtr),
+                    qr: `https://irma.app/-/session#${encodeURIComponent(JSON.stringify(this._mappings.sessionPtr))}`,
                     showBackButton: prevTransition === 'chooseQR',
                   },
                 }


### PR DESCRIPTION
We noticed some of our users scan QR codes with their camera app instead of directly in Yivi. The Yivi mobile app will pick up this link, and so will the camera. If the Yivi app is not installed it will redirect to the Yivi download page. Hopefully resulting in a more user friendly experience.

Maybe this needs some discussion but locally I checked it and it works nicely for us (android and ios), I'm not a mobile development expert so I could very well be overlooking things. But I didn't want to make an issue without a proposed solution.