### PR TITLE
Makes "Open Yivi App" link work on iOS in iframe

### DIFF
--- a/plugins/yivi-web/dom-manipulations.js
+++ b/plugins/yivi-web/dom-manipulations.js
@@ -42,7 +42,15 @@ module.exports = class DOMManipulations {
   setButtonLink(link) {
     const anchor = this._element.querySelector('.yivi-web-button-link');
     anchor.setAttribute('href', link);
-    anchor.setAttribute('target', '_top');
+
+    // On iOS the https://irma.app/-/session#[...] url does not open
+    // the Yivi app within an iframe.  Setting target="_top" solves this.
+    //
+    // But setting target="_top" breaks Adroid intent links.
+    // Whence:
+    if (!link.startsWith('intent')) {
+      anchor.setAttribute('target', '_top');
+    }
   }
 
   _renderInitialState() {

--- a/plugins/yivi-web/dom-manipulations.js
+++ b/plugins/yivi-web/dom-manipulations.js
@@ -40,7 +40,7 @@ module.exports = class DOMManipulations {
   }
 
   setButtonLink(link) {
-    this._element.querySelector('.yivi-web-button-link').setAttribute('href', link);
+    this._element.querySelector('.yivi-web-button-link').setAttribute('href', link).setAttribute('target', '_top');
   }
 
   _renderInitialState() {

--- a/plugins/yivi-web/dom-manipulations.js
+++ b/plugins/yivi-web/dom-manipulations.js
@@ -40,7 +40,9 @@ module.exports = class DOMManipulations {
   }
 
   setButtonLink(link) {
-    this._element.querySelector('.yivi-web-button-link').setAttribute('href', link).setAttribute('target', '_top');
+    const anchor = this._element.querySelector('.yivi-web-button-link');
+    anchor.setAttribute('href', link);
+    anchor.setAttribute('target', '_top');
   }
 
   _renderInitialState() {


### PR DESCRIPTION
The "Open Yivi App" link currently does not work on iOS/Safari within an `iframe`, see:

https://bram.westerbaan.name/tmp/yivi.html

Instead of opening the yivi app, Safari visits `https://irma.app/-/session#[...]`.

Setting `target="_top"` on the "Open Yivi App" <https://irma.app/-/session#[...]>  link used on iOS solves this problem, which is the content of this merge request.

(I tested the change on iOS, ~~but not~~ and on android.)
