### PR TITLE
fix(ci): disable workspaces-update so prepare doesn't resolve unpublished cross-refs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,4 +60,14 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npm run release
+        # `workspaces-update=false` stops `npm version` (run by
+        # @semantic-release/npm during prepare) from refreshing the
+        # lockfile. Without it, npm tries to resolve the
+        # just-cascaded `@privacybydesign/yivi-core@1.0.0` (etc.)
+        # against the registry — but those versions haven't been
+        # published yet — and fails with ETARGET. Known
+        # multi-semantic-release + npm-workspaces interaction:
+        # https://github.com/dhoulb/multi-semantic-release/issues/112
+        run: |
+          npm config set workspaces-update false
+          npm run release


### PR DESCRIPTION
## Summary

[Run #25791455797](https://github.com/privacybydesign/yivi-frontend-packages/actions/runs/25791455797/job/75757797034) got past OIDC (the npmjs.com Trusted Publisher setup fixed that ✅) and died at the prepare step:

```
npm error code ETARGET
npm error notarget No matching version found for @privacybydesign/yivi-core@1.0.0.
```

## What's happening

`@semantic-release/npm`'s `prepare` runs `npm version 1.0.0` for each of the 8 packages **in parallel**. By that point `multi-semantic-release` has already cascaded yivi-popup's `@privacybydesign/yivi-core` dep from `*` to `1.0.0` (exact, per our `--deps.bump=override` flag).

`npm version` in npm 11 refreshes the lockfile, which forces resolution of `yivi-core@1.0.0` — a version that doesn't exist on the registry yet, because yivi-core's publish is racing yivi-popup's prepare in the same parallel batch. ETARGET.

## The fix

One npm config setting before `multi-semantic-release` runs:

```yaml
npm config set workspaces-update false
```

This makes `npm version` skip the lockfile refresh, so the unpublished cross-ref never gets resolved against the registry. The workspace packages still get their own versions bumped fine.

This is the documented workaround for the known `multi-semantic-release` ↔ npm-workspaces interaction: [dhoulb/multi-semantic-release#112](https://github.com/dhoulb/multi-semantic-release/issues/112).

## Expected behavior

On merge, the Release workflow runs again, OIDC stays green, prepare succeeds, and all 8 packages publish `1.0.0` with provenance.

## Test plan

- [ ] Merge.
- [ ] Watch the Release run; confirm all 8 packages publish `1.0.0`.