### PR TITLE
fix(ci): set workspaces-update via env var, not npm config set

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,14 +60,18 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # `workspaces-update=false` stops `npm version` (run by
-        # @semantic-release/npm during prepare) from refreshing the
-        # lockfile. Without it, npm tries to resolve the
-        # just-cascaded `@privacybydesign/yivi-core@1.0.0` (etc.)
-        # against the registry — but those versions haven't been
-        # published yet — and fails with ETARGET. Known
-        # multi-semantic-release + npm-workspaces interaction:
-        # https://github.com/dhoulb/multi-semantic-release/issues/112
-        run: |
-          npm config set workspaces-update false
-          npm run release
+          # `workspaces-update=false` stops `npm version` (run by
+          # @semantic-release/npm during prepare) from refreshing the
+          # lockfile. Without it, npm tries to resolve the
+          # just-cascaded `@privacybydesign/yivi-core@1.0.0` (etc.)
+          # against the registry — but those versions haven't been
+          # published yet — and fails with ETARGET.
+          #
+          # Setting via env (not `npm config set`) is required because
+          # @semantic-release/npm spawns `npm version` with
+          # `--userconfig /tmp/<id>/.npmrc`, which overrides
+          # `~/.npmrc`. Env vars beat userconfig in npm's precedence
+          # order. Known multi-semantic-release ↔ npm-workspaces
+          # interaction: https://github.com/dhoulb/multi-semantic-release/issues/112
+          NPM_CONFIG_WORKSPACES_UPDATE: 'false'
+        run: npm run release


### PR DESCRIPTION
## Summary

[Run #25791711353](https://github.com/privacybydesign/yivi-frontend-packages/actions/runs/25791711353/job/75758670536) still hit the same ETARGET on `@privacybydesign/yivi-core@1.0.0` during prepare, despite #59 adding `npm config set workspaces-update false`.

## Root cause

`@semantic-release/npm` spawns `npm version` with `--userconfig /tmp/<id>/.npmrc` — a temporary npmrc it writes for auth. That flag makes npm read user config **from that temp file**, ignoring `~/.npmrc` entirely. So our `npm config set` (which writes `~/.npmrc`) was silently dropped.

You can see the override in the failing log:

```
npm version 1.0.0 --userconfig /tmp/ef55cf624c7f6746a2507aefc11aec0a/.npmrc --no-git-tag-version --allow-same-version
```

## Fix

Set the same config via **env var** instead. npm's config precedence is CLI flags > env vars > project npmrc > user npmrc > global > defaults, so `NPM_CONFIG_WORKSPACES_UPDATE=false` beats `--userconfig` and reaches the npm-version subprocess.

## Test plan

- [ ] Merge.
- [ ] Watch the Release run; confirm prepare succeeds for yivi-popup / yivi-frontend / etc. and all 8 packages publish `1.0.0` with provenance.