### PR TITLE
chore(ci): bump GitHub Actions to latest majors

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -50,7 +50,7 @@ jobs:
     - run: cd ./yivi-css && npm run clean
     - run: npm run build
     - name: Upload GitHub Pages artifact
-      uses: actions/upload-pages-artifact@v4
+      uses: actions/upload-pages-artifact@v5
       with:
         path: docs/
 
@@ -70,7 +70,7 @@ jobs:
     needs: build
     steps:
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -16,6 +16,6 @@ jobs:
     name: Conventional Commit
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Clears the Node.js 20 deprecation warnings GitHub Actions emits when running older action versions.

| Action | Before | After | Why bump |
|---|---|---|---|
| `actions/upload-pages-artifact` | v4 | v5 | v5 runs on Node.js 24 (v4 on Node 20) |
| `actions/configure-pages` | v5 | v6 | v6 runs on Node.js 24 (v5 on Node 20) |
| `actions/deploy-pages` | v4 | v5 | v5 runs on Node.js 24 (v4 on Node 20) |
| `amannn/action-semantic-pull-request` | v5 | v6 | v6 runs on Node.js 24 + ESM |

`actions/checkout@v6` and `actions/setup-node@v6` are already current.

## Breaking changes

None for our usage. The only breaking change in this batch is `configure-pages@v6`'s drop of Next.js < 13.3 support under `static_site_generator: next`, and we don't use that input.

## Test plan

- [ ] PR Title workflow passes on this PR (validates `action-semantic-pull-request@v6`).
- [ ] Merge; confirm the Node.js CI run on master no longer prints the deprecation warning banner.