### PR TITLE
fix: close stale issues (#37, #43, #45, #46, #54)

### DIFF
--- a/examples/browser/yivi-web-minimal/index.js
+++ b/examples/browser/yivi-web-minimal/index.js
@@ -10,12 +10,10 @@ const yivi = new YiviCore({
   element: '#yivi-qr',
   language: 'en',
   minimal: true,
-  qrPayload: `https://open.yivi.app/-/session#${encodeURIComponent(
-    JSON.stringify({
-      u: 'abcdef0123456789abcdef0123456789',
-      irmaqr: 'disclosing',
-    }),
-  )}`,
+  qrPayload: {
+    u: 'abcdef0123456789abcdef0123456789',
+    irmaqr: 'disclosing',
+  },
 });
 
 yivi.use(YiviWeb);

--- a/examples/browser/yivi-web/index.js
+++ b/examples/browser/yivi-web/index.js
@@ -7,12 +7,10 @@ import { YiviDummy } from '@privacybydesign/yivi-dummy';
 const yivi = new YiviCore({
   debugging: true,
   dummy: 'happy path',
-  qrPayload: `https://open.yivi.app/-/session#${encodeURIComponent(
-    JSON.stringify({
-      u: 'abcdef0123456789abcdef0123456789',
-      irmaqr: 'disclosing',
-    }),
-  )}`,
+  qrPayload: {
+    u: 'abcdef0123456789abcdef0123456789',
+    irmaqr: 'disclosing',
+  },
   element: '#yivi-web-form',
   language: 'en',
   translations: {

--- a/plugins/yivi-web/src/dom-manipulations.ts
+++ b/plugins/yivi-web/src/dom-manipulations.ts
@@ -95,7 +95,16 @@ export class DOMManipulations {
   }
 
   setButtonLink(link: string): void {
-    this._element.querySelector('.yivi-web-button-link')?.setAttribute('href', link);
+    const anchor = this._element.querySelector('.yivi-web-button-link');
+    if (!anchor) return;
+    anchor.setAttribute('href', link);
+    // Inside an iframe on iOS Safari the universal link navigates the iframe
+    // itself instead of opening the Yivi app. Targeting _top lets Safari hand
+    // the URL off to the OS so the app can claim it. Skipped for Android
+    // intent:// links, where _top would break the intent fallback chain.
+    if (!link.startsWith('intent')) {
+      anchor.setAttribute('target', '_top');
+    }
   }
 
   private _renderInitialState(): void {

--- a/plugins/yivi-web/src/dom-manipulations.ts
+++ b/plugins/yivi-web/src/dom-manipulations.ts
@@ -126,13 +126,11 @@ export class DOMManipulations {
       const isAndroid = /Android/i.test(window.navigator.userAgent);
       if (target.matches('[data-yivi-glue-transition]')) {
         this._clickCallback(target.getAttribute('data-yivi-glue-transition') || '');
-      } else if (isAndroid && target.matches('.yivi-web-button-link *')) {
-        (target as HTMLButtonElement).disabled = true;
+      } else if (isAndroid && target.matches('.yivi-web-button-link')) {
         setTimeout(() => {
-          // Only activate helper if the button to open the Yivi app is still present after the timeout.
+          // Only activate helper if the link to open the Yivi app is still present after the timeout.
           if (this._element.contains(target)) {
             this._element.querySelector('.yivi-web-header')?.classList.add('yivi-web-show-helper');
-            (target as HTMLButtonElement).disabled = false;
           }
         }, this._fallbackDelay);
       } else if (target.matches('.yivi-web-pairing-code')) {

--- a/yivi-css/src/components/yivi-form.scss
+++ b/yivi-css/src/components/yivi-form.scss
@@ -159,8 +159,14 @@ Styleguide Components.Yivi login
 
       background-color: $helper-color;
 
+      // visibility hides the helper from the focus order while it is
+      // translated off-screen, so Tab cannot land on the link inside it
+      // and force the browser to scroll the overflow:hidden header.
+      visibility: hidden;
       transform: translateX(120%);
-      @include transition(transform 0.4s ease);
+      transition:
+        transform 0.4s ease,
+        visibility 0s 0.4s;
 
       a {
         @include font($color: $yivi-anthracite, $weight: 400);
@@ -186,7 +192,11 @@ Styleguide Components.Yivi login
       }
 
       .yivi-web-helper {
+        visibility: visible;
         transform: translateX(0%);
+        transition:
+          transform 0.4s ease,
+          visibility 0s 0s;
       }
     }
 


### PR DESCRIPTION
## Summary

Audit of all remaining open issues (#37, #43, #45, #46, #54) and open PRs (#24, #34, #61), plus two follow-on bugs uncovered while reproducing #37 in the browser.

### Open issues

#### #37 — Tab key breaks popup header (fixed: 0ab0b66)

The `.yivi-web-helper` lives inside an `overflow:hidden` header and is parked off-screen via `transform: translateX(120%)`. Its descendant link stayed in the tab order, so once Tab focused it the browser scrolled the parent's overflow to expose the focused element — visibly breaking the header layout. Reproduced manually on http://localhost:8089/ before fix; confirmed fixed after.

Adding `visibility: hidden` while the helper is off-screen removes the subtree from the focus order and the accessibility tree, so Tab skips it and there is nothing for the browser to scroll to. `visibility` is transitioned with a delay equal to the slide duration so the existing animation is preserved (delayed on the way out, immediate on the way in).

#### #43 — Fix github workflow pipeline, gh pages broken

Already resolved by 73673e5 (`chore(ci): remove GitHub Pages deploy and docs/ folder`) and 99463fc (`chore(yivi-css): drop dead styleguide scripts and devDeps`).

#### #45 — Button in anchor

Already resolved by the JS→TS refactor. The old `<a><button>…</button></a>` pattern is gone; the current markup is a single `<a class="yivi-web-button-link yivi-web-button">` (`plugins/yivi-web/src/dom-manipulations.ts:310-312`).

#### #46 — Font size in pixels

Already resolved: `$default-font-size` is now `1rem` (`yivi-css/src/variables/fonts.scss:10`). No remaining `font-size: *px` rules in `yivi-css/src/`.

#### #54 — Feedback coffeebrick

Already addressed: `prepare-release.sh` (the file with the `var` usage) is gone, and pairing-form buttons are styled via explicit `yivi-web-button-secondary` class loaded from `@use './yivi-button'`.

### Open PRs

#### #34 — Makes "Open Yivi App" link work on iOS in iframe (picked up: 2edf044)

Real iOS Safari iframe bug. Ported `target="_top"` fix from the original JS patch into the current TS code (`setButtonLink` in `dom-manipulations.ts`). #34 closed as superseded. Credit to @awesterb.

#### #61 — Dependabot: bump serialize-javascript / terser-webpack-plugin

Closed as stale. Only modified `yivi-frontend/package-lock.json`, but with npm workspaces the per-workspace lock files are no longer authoritative — only root `package-lock.json` is used for installs. The version it replaces (v6.0.2) is already past the CVE anyway.

#### #24 — Add explanation section

Closed as stale draft. Was a draft feature for ~2 years against the old JS codebase; reviewer feedback was never addressed; the touched files have all been refactored to TS. Feature can be reproposed fresh.

### Follow-on fixes uncovered while reproducing #37

- **`fix(yivi-web): restore Android fallback-helper trigger` (e9829a6)** — the #45 anchor flattening also broke the Android fallback that swaps the header for "Can't figure it out?": the click handler matched `.yivi-web-button-link *` (descendants of the link), but after flattening the link has no element children. Switched to matching the `<a>` directly and dropped the dead `target.disabled = ...` lines (anchors don't have a `disabled` property).
- **`fix(examples): pass qrPayload as sessionPtr object, not pre-built URL` (d42d501)** — `YiviDummy._getUniversalLink` spreads `qrPayload` (`...this._options.qrPayload`) and wraps the result in the deeplink URL. Both browser examples were passing a fully-built URL string instead, which got spread character-by-character into `{"0":"h","1":"t",…,"continueOnSecondDevice":true}` and produced an unnecessarily dense ~600-char QR. Switched to passing the sessionPtr object that the dummy expects.

## Test plan

- [x] `npm run build:css` compiles
- [x] `npm run lint` clean (js + css)
- [x] `npm run typecheck` clean
- [x] `npm test` — 61 tests pass
- [x] Manual: Tab repeatedly in the browser example — pre-fix, header breaks immediately on first Tab; post-fix, no break
- [ ] Manual on a real Android device (or Chrome devtools Android UA): click "Open Yivi app", wait 1s, helper text appears
- [ ] Manual on iOS Safari inside an iframe: clicking the Yivi-app link opens the OS app (not Safari navigating the iframe)

Closes #37, #43, #45, #46, #54.