### PR TITLE
chore(ci): disable semantic-release success comment on PRs

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -12,6 +12,11 @@
         "npmPublish": true
       }
     ],
-    "@semantic-release/github"
+    [
+      "@semantic-release/github",
+      {
+        "successComment": false
+      }
+    ]
   ]
 }


### PR DESCRIPTION
## Summary
- Disables the `@semantic-release/github` plugin's "🎉 This PR is included in version …" comment by setting `successComment: false` in `.releaserc.json`.
- The comment fired on every released PR (and linked issues), duplicating info that's already in the GitHub release notes.
- Keep @ivard 's mailbox from catching on fire.

## Test plan
- [ ] On the next release to `master`, confirm no success comment is posted on the included PRs.