### PR TITLE
fix(yivi-frontend): build browser-safe ESM via tsdown platform: browser

### DIFF
--- a/tests/integration/yivi-frontend-browser-safety.test.ts
+++ b/tests/integration/yivi-frontend-browser-safety.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// Regression guard for the bug fixed in PR #72 (refs issue #71):
+// the published ESM bundle was loading qrcode's Node entry, which pulled in
+// pngjs and Node built-ins via `createRequire(import.meta.url)`. Browser
+// bundlers (Vite, etc.) externalize `node:module`, so the bundle crashed on
+// first evaluation. These assertions run against the built artifact and fail
+// fast if a future change reintroduces a Node-only dependency in the ESM.
+
+const esmBundlePath = resolve(
+  __dirname,
+  '../../yivi-frontend/dist/index.mjs',
+);
+
+describe('yivi-frontend ESM bundle browser safety', () => {
+  const bundle = readFileSync(esmBundlePath, 'utf8');
+
+  it('does not import from node:module', () => {
+    expect(bundle).not.toMatch(/from\s+["']node:module["']/);
+  });
+
+  it('does not call createRequire', () => {
+    expect(bundle).not.toMatch(/createRequire\s*\(/);
+  });
+
+  it('does not bundle Node built-ins via __require', () => {
+    const nodeBuiltins = ['fs', 'stream', 'zlib', 'util', 'assert', 'buffer'];
+    for (const builtin of nodeBuiltins) {
+      const pattern = new RegExp(`__require\\(["']${builtin}["']\\)`);
+      expect(bundle, `Node built-in "${builtin}" leaked into ESM bundle`).not.toMatch(pattern);
+    }
+  });
+
+  it('does not bundle pngjs (Node-only PNG encoder)', () => {
+    expect(bundle).not.toMatch(/node_modules\/pngjs\//);
+  });
+});

--- a/tests/integration/yivi-frontend-browser-safety.test.ts
+++ b/tests/integration/yivi-frontend-browser-safety.test.ts
@@ -9,10 +9,7 @@ import { resolve } from 'node:path';
 // first evaluation. These assertions run against the built artifact and fail
 // fast if a future change reintroduces a Node-only dependency in the ESM.
 
-const esmBundlePath = resolve(
-  __dirname,
-  '../../yivi-frontend/dist/index.mjs',
-);
+const esmBundlePath = resolve(__dirname, '../../yivi-frontend/dist/index.mjs');
 
 describe('yivi-frontend ESM bundle browser safety', () => {
   const bundle = readFileSync(esmBundlePath, 'utf8');

--- a/yivi-frontend/tsdown.config.ts
+++ b/yivi-frontend/tsdown.config.ts
@@ -4,7 +4,10 @@ export default defineConfig({
   entry: ['src/index.ts'],
   format: ['esm', 'cjs'],
   dts: true,
-
+  platform: 'browser',
+  // platform: 'browser' defaults fixedExtension to false (outputs .js/.cjs);
+  // keep it true so we stay compatible with the existing .mjs/.cjs exports map.
+  fixedExtension: true,
   sourcemap: true,
   clean: false, // Don't clean as we also have webpack output
   deps: {


### PR DESCRIPTION
## Summary

- Fix #71 — `yivi-frontend@1.0.x`'s ESM bundle (`dist/index.mjs`) crashes in browsers with `Uncaught TypeError: ... createRequire is not a function`. Root cause: tsdown was bundling `qrcode`'s Node entry, which transitively pulls in `pngjs` and Node built-ins (`util`/`stream`/`zlib`/`fs`/`assert`/`buffer`) via a `createRequire(import.meta.url)` shim — fine in Node, fatal under any browser bundler (Vite externalizes `node:module`).
- Set `platform: 'browser'` in `yivi-frontend/tsdown.config.ts` so `qrcode`'s `browser` field is honored and `pngjs` is no longer bundled into the ESM output.
- Add `fixedExtension: true` so the output filenames stay `.mjs`/`.cjs` (tsdown defaults `fixedExtension` to `false` when `platform: 'browser'`); without this, the bundle would be written as `index.js`, which doesn't match the existing `exports` map.

## Why this approach

Three options were considered (see #71):

1. Re-add the `"browser"` exports condition pointing at the webpack-polyfilled `dist/yivi.js`.
2. Build a browser-safe ESM with tsdown (**this PR**).
3. Externalize the Node-only deps in tsdown so they aren't bundled at all.

Option 2 is the cleanest going forward: browser consumers get a real, lean ESM (smaller bundle, tree-shakeable, no polyfill surprises) instead of being silently redirected to the UMD. The webpack `dist/yivi.js` is still produced and is still reachable via the `./umd` export for legacy consumers.

## Verification

Built locally against `openid4vp-demo-frontend` (Vite 8 + React 19, the project that originally hit the crash):

- `npm run build` in `yivi-frontend/`: succeeds; `dist/index.mjs` drops from ~270 kB → ~127 kB.
- `grep -c "node:module\|createRequire\|pngjs" dist/index.mjs` → **0**.
- Linked into the consumer (`npm install --no-save ../yivi-frontend-packages/yivi-frontend`):
  - Vite no longer prints the `Module "node:module" has been externalized` warning.
  - Console is clean of the `createRequire is not a function` error.
  - App renders correctly; `newPopup()` import works across all four tabs (IRMA / EUDI / Veramo Verifier / Veramo Issuer).

## Test plan

- [ ] CI: `npm run build` in `yivi-frontend/` passes (both `build:esm` and `build:webpack`).
- [ ] Inspect `dist/index.mjs` of the built artifact — no `node:module`, no `createRequire`, no `pngjs`.
- [ ] Smoke test: install the resulting tarball into a fresh Vite + React app, `import { newPopup } from "@privacybydesign/yivi-frontend"`, run `vite dev`, confirm no console errors on load.
- [ ] Smoke test (Node): `require("@privacybydesign/yivi-frontend")` still loads the CJS entry without erroring (CJS path unchanged in behavior, but worth a sanity check given the platform switch).