### PR TITLE
fix(yivi-web): restore link-style appearance for "Show QR code" button

### DIFF
--- a/plugins/yivi-web/src/dom-manipulations.ts
+++ b/plugins/yivi-web/src/dom-manipulations.ts
@@ -317,7 +317,7 @@ export class DOMManipulations {
       <a class="yivi-web-button-link yivi-web-button">
         ${this._translations.button}
       </a>
-      <p><button class="yivi-web-button-secondary" data-yivi-glue-transition="chooseQR">${this._translations.qrCode}</button></p>
+      <p><button class="yivi-web-button-tertiary" data-yivi-glue-transition="chooseQR">${this._translations.qrCode}</button></p>
     `;
   }
 


### PR DESCRIPTION
## Summary
- The "Show QR code" switch control used to render as blue underlined link text (it was an `<a>` tag with default link styling).
- Commit 8d21975 ("Replace anchor tags with semantic buttons in DOM manipulations") changed it to a semantic `<button class="yivi-web-button-secondary">`, which renders as a filled white button with an anthracite border — visually heavier than the original link.
- This PR switches the class to `yivi-web-button-tertiary` (`color: $content-link-color; text-decoration: underline;`), restoring the link-style appearance while keeping the semantic `<button>` element from 8d21975.

Cancel/retry controls keep the secondary (outlined) style.

## Test plan
- [ ] Build `yivi-web` and load the styleguide; confirm the "Show QR code" control renders as blue underlined text.
- [ ] Click it and confirm `chooseQR` transition still fires.
- [ ] Verify cancel/retry buttons in the QR/app states still render with the secondary outlined style.